### PR TITLE
Bug fix: Picasso simulate crashes when opening

### DIFF
--- a/picasso/simulate.py
+++ b/picasso/simulate.py
@@ -365,7 +365,7 @@ def generatePositions(number, imagesize, frame, arrangement):
     Generate a set of positions where structures will be placed
     """
     if arrangement == 0:
-        spacing = _np.ceil((number ** 0.5))
+        spacing = int(_np.ceil((number ** 0.5)))
         linpos = _np.linspace(frame, imagesize - frame, spacing)
         [xxgridpos, yygridpos] = _np.meshgrid(linpos, linpos)
         xxgridpos = _np.ravel(xxgridpos)


### PR DESCRIPTION
Picasso simulate -> generatePositions() -> linpos.

Changed spacing type to int as newer numpy versions do not accept floats in the numpy linspace function.

Tested with Picasso 0.3.0
numpy version 1.11.3 (accepts floats in np.linspace)
numpy version 1.18.1 (does not accept floats -> create int from np.ceil return)

fixed #98