### PR TITLE
Added clustering menu (-> DBSCAN, HDBSCAN) to postprocessing menu

### DIFF
--- a/picasso/gui/render.py
+++ b/picasso/gui/render.py
@@ -6086,10 +6086,11 @@ class Window(QtWidgets.QMainWindow):
         apply_action.setShortcut("Ctrl+A")
         apply_action.triggered.connect(self.open_apply_dialog)
 
-        dbscan_action = postprocess_menu.addAction("DBSCAN")
+        postprocess_menu.addSeparator()
+        clustering_menu = postprocess_menu.addMenu("Clustering")
+        dbscan_action = clustering_menu.addAction("DBSCAN")
         dbscan_action.triggered.connect(self.view.dbscan)
-
-        hdbscan_action = postprocess_menu.addAction("HDBSCAN")
+        hdbscan_action = clustering_menu.addAction("HDBSCAN")
         hdbscan_action.triggered.connect(self.view.hdbscan)
 
         self.load_user_settings()


### PR DESCRIPTION
This adds a menu to render -> postprocessing -> "clustering" which opens the options DBSCAN & HDBSCAN while hovering over "clustering" (point 2 of comment in #100).

![Render_Postprocess_SCANS_clustering_menu](https://user-images.githubusercontent.com/48733135/81018043-fa45b400-8e63-11ea-9048-881c1251d899.png)
