### PR TITLE
Filter string in localize open file dialog fixed

### DIFF
--- a/picasso/gui/localize.py
+++ b/picasso/gui/localize.py
@@ -959,7 +959,7 @@ class Window(QtWidgets.QMainWindow):
             dir = self.pwd
 
         path, exe = QtWidgets.QFileDialog.getOpenFileName(
-            self, "Open image sequence", directory=dir, filter="*.raw; *.tif"
+            self, "Open image sequence", directory=dir, filter="All supported formats (*.raw *.tif *.tiff);;Raw files (*.raw);;Tiff iimages (*.tif *.tiff)"
         )
         if path:
             self.pwd = path


### PR DESCRIPTION
Only tif files could be opened, because the filter sting in the localize module for the file open dialog was in the wrong format. Correct format is
`All supported formats (*.raw *.tif *.tiff);;Raw files (*.raw);;Tiff iimages (*.tif *.tiff)`
Correct formatting taken from https://doc.qt.io/qtforpython/PySide2/QtWidgets/QFileDialog.html - PySide2.QtWidgets.PySide2.QtWidgets.QFileDialog.getOpenFileName