### PR TITLE
3d group display

### DIFF
--- a/picasso/gui/render.py
+++ b/picasso/gui/render.py
@@ -3512,24 +3512,57 @@ class View(QtWidgets.QLabel):
             if channel is (len(self.locs_paths)):
                 n_channels = len(self.locs_paths)
                 colors = get_colors(n_channels)
-
+                
+                x_means = np.zeros(len(self.locs_paths))
+                y_means = np.zeros(len(self.locs_paths))
+                z_means = np.zeros(len(self.locs_paths))
+                x_ranges = np.zeros(len(self.locs_paths))
+                y_ranges = np.zeros(len(self.locs_paths))
+                z_ranges = np.zeros(len(self.locs_paths))
                 for i in range(len(self.locs_paths)):
                     locs = self.picked_locs(i)
                     locs = stack_arrays(locs, asrecarray=True, usemask=False)
                     ax.scatter(locs["x"], locs["y"], locs["z"], c=colors[i], s=2)
+                    
+                    x_means[i] = np.mean(locs["x"])
+                    y_means[i] = np.mean(locs["y"])
+                    z_means[i] = np.mean(locs["z"])
+                    x_ranges[i] = 3 * np.std(locs["x"])
+                    y_ranges[i] = 3 * np.std(locs["y"])
+                    z_ranges[i] = 3 * np.std(locs["z"])
+                
+                x_mean = np.mean(x_means)
+                y_mean = np.mean(y_means)
+                z_mean = np.mean(z_means)
+                x_range = np.amax(x_ranges)
+                y_range = np.amax(y_ranges)
+                z_range = np.amax(z_ranges)
+                xy_range = max(x_range, y_range)
 
                 ax.set_xlim(
-                    np.mean(locs["x"]) - 3 * np.std(locs["x"]),
-                    np.mean(locs["x"]) + 3 * np.std(locs["x"]),
+                    x_mean - xy_range,
+                    x_mean + xy_range,
                 )
                 ax.set_ylim(
-                    np.mean(locs["y"]) - 3 * np.std(locs["y"]),
-                    np.mean(locs["y"]) + 3 * np.std(locs["y"]),
+                    y_mean - xy_range,
+                    y_mean + xy_range,
                 )
+                
+                
                 ax.set_zlim(
-                    np.mean(locs["z"]) - 3 * np.std(locs["z"]),
-                    np.mean(locs["z"]) + 3 * np.std(locs["z"]),
+                    z_mean - z_range,
+                    z_mean + z_range,
                 )
+                
+                plt.gca().patch.set_facecolor("black")
+                ax.set_xlabel("X [Px]")
+                ax.set_ylabel("Y [Px]")
+                ax.set_zlabel("Z [nm]")
+                ax.w_xaxis.set_pane_color((0, 0, 0, 1.0))
+                ax.w_yaxis.set_pane_color((0, 0, 0, 1.0))
+                ax.w_zaxis.set_pane_color((0, 0, 0, 1.0))
+                fig.canvas.draw()
+                fig.show()
 
 
             else:
@@ -3548,6 +3581,7 @@ class View(QtWidgets.QLabel):
                     else:
                         show_group = None
 
+                    
                 if show_group == "yes":
                     locs = self.picked_locs(channel, 
                                             add_group=False,
@@ -3563,18 +3597,22 @@ class View(QtWidgets.QLabel):
                     ax.scatter(
                         locs["x"], locs["y"], locs["z"], c=colors, cmap="jet", s=2)
     
+                    x_range = 3 * np.std(locs["x"])
+                    y_range = 3 * np.std(locs["y"])
+                    xy_range = max(x_range, y_range)
+    
                     ax.set_xlim(
-                        np.mean(locs["x"]) - 3 * np.std(locs["x"]),
-                        np.mean(locs["x"]) + 3 * np.std(locs["x"]),
+                        np.mean(locs["x"]) - xy_range,
+                        np.mean(locs["x"]) + xy_range,
                     )
                     ax.set_ylim(
-                        np.mean(locs["y"]) - 3 * np.std(locs["y"]),
-                        np.mean(locs["y"]) + 3 * np.std(locs["y"]),
+                        np.mean(locs["y"]) - xy_range,
+                        np.mean(locs["y"]) + xy_range,
                     )
                     ax.set_zlim(
                         np.mean(locs["z"]) - 3 * np.std(locs["z"]),
                         np.mean(locs["z"]) + 3 * np.std(locs["z"]),
-                    )                    
+                    )                
 
                 if show_group == "no":
                     locs = self.picked_locs(channel)
@@ -3590,28 +3628,34 @@ class View(QtWidgets.QLabel):
                     ax.scatter(
                         locs["x"], locs["y"], locs["z"], c=colors, cmap="jet", s=2)
 
+                    x_range = 3 * np.std(locs["x"])
+                    y_range = 3 * np.std(locs["y"])
+                    xy_range = max(x_range, y_range)
+    
                     ax.set_xlim(
-                        np.mean(locs["x"]) - 3 * np.std(locs["x"]),
-                        np.mean(locs["x"]) + 3 * np.std(locs["x"]),
+                        np.mean(locs["x"]) - xy_range,
+                        np.mean(locs["x"]) + xy_range,
                     )
                     ax.set_ylim(
-                        np.mean(locs["y"]) - 3 * np.std(locs["y"]),
-                        np.mean(locs["y"]) + 3 * np.std(locs["y"]),
+                        np.mean(locs["y"]) - xy_range,
+                        np.mean(locs["y"]) + xy_range,
                     )
                     ax.set_zlim(
                         np.mean(locs["z"]) - 3 * np.std(locs["z"]),
                         np.mean(locs["z"]) + 3 * np.std(locs["z"]),
-                    )
-
-            plt.gca().patch.set_facecolor("black")
-            ax.set_xlabel("X [Px]")
-            ax.set_ylabel("Y [Px]")
-            ax.set_zlabel("Z [nm]")
-            ax.w_xaxis.set_pane_color((0, 0, 0, 1.0))
-            ax.w_yaxis.set_pane_color((0, 0, 0, 1.0))
-            ax.w_zaxis.set_pane_color((0, 0, 0, 1.0))
-            fig.canvas.draw()
-            fig.show()
+                    )       
+                    
+                if show_group != None:
+                    plt.gca().patch.set_facecolor("black")
+                    ax.set_xlabel("X [Px]")
+                    ax.set_ylabel("Y [Px]")
+                    ax.set_zlabel("Z [nm]")
+                    ax.w_xaxis.set_pane_color((0, 0, 0, 1.0))
+                    ax.w_yaxis.set_pane_color((0, 0, 0, 1.0))
+                    ax.w_zaxis.set_pane_color((0, 0, 0, 1.0))
+                    fig.canvas.draw()
+                    fig.show()
+    
 
     @check_pick
     def show_trace(self):

--- a/picasso/gui/render.py
+++ b/picasso/gui/render.py
@@ -625,7 +625,7 @@ class PlotDialogIso(QtWidgets.QDialog):
                 np.mean(locs["y"]) + 3 * np.std(locs["y"]),
             )
             ax2.set_title("XY")
-            ax2.set_axis_bgcolor("black")
+            ax2.set_facecolor("black")
 
             # AXES 3
             ax3.scatter(locs["x"], locs["z"], c=colors, cmap="jet", s=2)
@@ -640,7 +640,7 @@ class PlotDialogIso(QtWidgets.QDialog):
                 np.mean(locs["z"]) + 3 * np.std(locs["z"]),
             )
             ax3.set_title("XZ")
-            ax3.set_axis_bgcolor("black")
+            ax3.set_facecolor("black")
 
             # AXES 4
             ax4.scatter(locs["y"], locs["z"], c=colors, cmap="jet", s=2)
@@ -655,7 +655,7 @@ class PlotDialogIso(QtWidgets.QDialog):
                 np.mean(locs["z"]) + 3 * np.std(locs["z"]),
             )
             ax4.set_title("YZ")
-            ax4.set_axis_bgcolor("black")
+            ax4.set_facecolor("black")
 
         else:
             colors = color_sys
@@ -700,7 +700,7 @@ class PlotDialogIso(QtWidgets.QDialog):
                 np.mean(locs["y"]) + 3 * np.std(locs["y"]),
             )
             ax2.set_title("XY")
-            ax2.set_axis_bgcolor("black")
+            ax2.set_facecolor("black")
 
             # AXES 3
             ax3.set_xlabel("X [Px]")
@@ -714,7 +714,7 @@ class PlotDialogIso(QtWidgets.QDialog):
                 np.mean(locs["z"]) + 3 * np.std(locs["z"]),
             )
             ax3.set_title("XZ")
-            ax3.set_axis_bgcolor("black")
+            ax3.set_facecolor("black")
 
             # AXES 4
             ax4.set_xlabel("Y [Px]")
@@ -728,7 +728,7 @@ class PlotDialogIso(QtWidgets.QDialog):
                 np.mean(locs["z"]) + 3 * np.std(locs["z"]),
             )
             ax4.set_title("YZ")
-            ax4.set_axis_bgcolor("black")
+            ax4.set_facecolor_bgcolor("black")
 
         result = dialog.exec_()
 
@@ -2246,7 +2246,6 @@ class SlicerDialog(QtWidgets.QDialog):
     def calculate_histogram(self):
         slice = self.pick_slice.value()
         ax = self.figure.add_subplot(111)
-        ax.hold(False)
         plt.cla()
         n_channels = len(self.zcoord)
 
@@ -2258,12 +2257,11 @@ class SlicerDialog(QtWidgets.QDialog):
             slice,
         )
         self.patches = []
-        ax.hold(True)
         for i in range(len(self.zcoord)):
             n, bins, patches = plt.hist(
                 self.zcoord[i],
                 self.bins,
-                normed=1,
+                density=1,
                 facecolor=self.colors[i],
                 alpha=0.5,
             )

--- a/picasso/gui/render.py
+++ b/picasso/gui/render.py
@@ -3533,19 +3533,26 @@ class View(QtWidgets.QLabel):
 
 
             else:
-                method = "no"
-                if hasattr(self.locs[channel], "group") and len(self.locs_paths)<=1:
-                    options = ["yes", "no"]
+                show_group = "no"
+                if (hasattr(self.locs[channel], "group") and 
+                    len(self.locs_paths) <= 1):
                     index, ok = QtWidgets.QInputDialog.getItem(
-                        self, "Select 3D Rendering", "Show groups?", options, editable=False
+                        self, 
+                        "Select 3D Rendering", 
+                        "Show groups?", 
+                        ["yes", "no"], 
+                        editable=False,
                     )
                     if ok:
-                        method = index
+                        show_group = index
                     else:
-                        method = None
+                        show_group = None
 
-                if method == "yes":
-                    locs = self.picked_locs(channel, add_group=False, keep_group_color=True)
+                if show_group == "yes":
+                    locs = self.picked_locs(channel, 
+                                            add_group=False,
+                                            keep_group_color=True,
+                    )
                     locs = stack_arrays(locs, asrecarray=True, usemask=False)
                     group_color = locs["group_color"]
                     colors = get_colors(N_GROUP_COLORS)
@@ -3569,7 +3576,7 @@ class View(QtWidgets.QLabel):
                         np.mean(locs["z"]) + 3 * np.std(locs["z"]),
                     )                    
 
-                if method == "no":
+                if show_group == "no":
                     locs = self.picked_locs(channel)
                     locs = stack_arrays(locs, asrecarray=True, usemask=False)
 

--- a/picasso/gui/render.py
+++ b/picasso/gui/render.py
@@ -4893,13 +4893,13 @@ class View(QtWidgets.QLabel):
         if self.x_render_state:
             locs = self.x_locs
             return self.render_multi_channel(
-                kwargs, autoscale=autoscale, locs=locs, use_cache=use_cache
+                kwargs, autoscale=autoscale, locs=locs, use_cache=use_cache 
             )
 
         if hasattr(locs, "group"):
             locs = [locs[self.group_color == _] for _ in range(N_GROUP_COLORS)]
             return self.render_multi_channel(
-                kwargs, autoscale=autoscale, locs=locs, use_cache=use_cache
+                kwargs, autoscale=autoscale, locs=locs, use_cache=use_cache, plot_channels=True
             )
 
         if hasattr(locs, "z"):


### PR DESCRIPTION
These changes aim to improve the display of 3D data in Picasso Render. I plan to make some further changes before merging it with the master branch.

Firstly, it contains a bug fix. The option View-Slice lead the following error message. Updating the outdated mathplotlib functions set_axis_bgcolor, ax.hold() and the plt.hist option "normed" fixed this issue. (credits to @rafalkowalewski1).
<img src="https://user-images.githubusercontent.com/83019886/121502759-c0d56580-c9e0-11eb-892d-67d97bd1b5af.PNG" width="400" height="400"/>

Secondly, slicing was enabled for 3D data containing group information. Unlike data, which does not have group information, the function View-Slice with ticked "Slice Dataset" does not selectively show the localizations of the current z-region, when grouped data is used (see below where two z-bins were chosen, but where the display did not change). 
<img src="https://user-images.githubusercontent.com/83019886/121504244-270eb800-c9e2-11eb-9562-abadadfe69a6.PNG" width="400" height="400"/> <img src="https://user-images.githubusercontent.com/83019886/121504255-283fe500-c9e2-11eb-89eb-c7d8f205d377.PNG" width="400" height="400"/>
By setting plot_channels=True in the respective function call, this issue gets fixed (credits to @rafalkowalewski1). 
<img src="https://user-images.githubusercontent.com/83019886/121505681-5245d700-c9e3-11eb-936b-b8971aa1331f.PNG" width="400" height="400"/> <img src="https://user-images.githubusercontent.com/83019886/121507143-a7ceb380-c9e4-11eb-88db-f34f5aabacdc.PNG" width="400" height="400"/>

Thirdly, the function Tools-Plot pick (XYZ scatter) was expanded: So far the localizations in this 3D view were colorcoded according to their z-position. Here, the option to maintain the colorcoding of grouped data was added. When having such a 3D dataset with group information, selecting Plot pick (XYZ scatter) first opens a menu where the user can choose wether the groups should be displayed or the standard z-colorcoding should be applied. 
The menu:
<img src="https://user-images.githubusercontent.com/83019886/121549984-9e5a4100-ca0e-11eb-823e-d2a62cf392c4.PNG" width="400" height="400"/>
Both rendering options:
<img src="https://user-images.githubusercontent.com/83019886/121550640-322c0d00-ca0f-11eb-9123-23facb818438.png" width="384" height="288"/> <img src="https://user-images.githubusercontent.com/83019886/121549643-54715b00-ca0e-11eb-9a54-65fa4fb89cf5.png" width="384" height="288"/>

Moreover, the x and y axis in this 3d plot can be scaled differently. For example this roughly circular NPC couples looks elliptical in the 3d plot. 
<img src="https://user-images.githubusercontent.com/83019886/125083518-cc43ab80-e0c8-11eb-9ba7-bd713092cf35.png" width="288" height="288"/> <img src="https://user-images.githubusercontent.com/83019886/125083658-f2694b80-e0c8-11eb-8613-755d26c5e8d9.png" width="288" height="288"/>

Something I realized is that the automatic choice of the z range displayed in the graph does not work properly when multiple files are shown. The automatic positioning only uses the localizations of the the last channel plotted. If other channels significantly differ in their z-position, it can look like this. The right figure shows the fix.

<img src="https://user-images.githubusercontent.com/83019886/125084135-7ae7ec00-e0c9-11eb-81a2-46f7b6dba9d5.PNG" width="288" height="288"/> <img src="https://user-images.githubusercontent.com/83019886/125084152-7de2dc80-e0c9-11eb-9503-1a5c108182c9.PNG" width="384" height="288"/>

ToDo:

- [ ] provide testdata and a test
- [ ] So far the 3D group display was only added for the Tools-Plot pick (XYZ scatter) function. Maybe it would be useful to have this option also in the Tools-Select picks (...) functions. 
- [x] If one clicks cancel in the newly introduced menu, then the empty graph pops up. Prevent this.
- [ ] document in readthedocs?
