### PR TITLE
Calibration file includes n_frames and step size. 

### DIFF
--- a/picasso/localize.py
+++ b/picasso/localize.py
@@ -203,7 +203,7 @@ def identify_async(movie, minimum_ng, box, roi=None):
     _io.save_user_settings(settings)
 
     n_workers = min(
-        60, max(1, int(0.75 * _multiprocessing.cpu_count()))
+        60, max(1, int(cpu_utilization * _multiprocessing.cpu_count()))
     ) # Python crashes when using >64 cores
 
     lock = _threading.Lock()

--- a/picasso/zfit.py
+++ b/picasso/zfit.py
@@ -59,6 +59,8 @@ def calibrate_z(locs, info, d, magnification_factor, path=None):
     calibration = {
         "X Coefficients": [float(_) for _ in cx],
         "Y Coefficients": [float(_) for _ in cy],
+        "Number of frames": int(n_frames),
+        "Step size in nm": float(d),
     }
     if path is not None:
         with open(path, "w") as f:


### PR DESCRIPTION

Also, Within localize.py the number of cpu utilizations was changed from 
`60, max(1, int(0.75 * _multiprocessing.cpu_count()))` in line 206 to
`60, max(1, int(cpu_utilization * _multiprocessing.cpu_count()))`.