### PR TITLE
mask in render can be saved as .png file

### DIFF
--- a/picasso/gui/render.py
+++ b/picasso/gui/render.py
@@ -3643,14 +3643,17 @@ class MaskSettingsDialog(QtWidgets.QDialog):
         self.H_blur = H_blur # image to be displayed in self.ax2
 
     def save_mask(self):
-        """ Saves binary mask into .npy format. """
+        """ Saves binary mask from .npy to a .png format """
 
         # get name for saving mask
         path, ext = QtWidgets.QFileDialog.getSaveFileName(
-            self, "Save mask to", filter="*.npy"
+            self, "Save mask to", "mask.png" ,filter="*.png;;*.npy"
         )
         if path:
-            np.save(path, self.mask)
+            if path.endswith(".png"):
+                plt.imsave(path, self.mask, cmap='gray')
+            elif path.endswith(".npy"):
+                np.save(path, self.mask)
 
     def load_mask(self):
         """ Loads binary mask from .npy format. """


### PR DESCRIPTION
# The mask can now be exported as .png file in render.py

- The mask in .npy format is saved as .png file using matplotlib.
- The option to save the array as a .npy format is still supported.
- The file will automatically named `mask.ext`. 