### PR TITLE
mask in render.py is simultaneously saved as a npy. and .png file  

### DIFF
--- a/picasso/gui/render.py
+++ b/picasso/gui/render.py
@@ -3643,14 +3643,17 @@ class MaskSettingsDialog(QtWidgets.QDialog):
         self.H_blur = H_blur # image to be displayed in self.ax2
 
     def save_mask(self):
-        """ Saves binary mask into .npy format. """
+        """ Saves binary mask from .npy to a .png format """
 
         # get name for saving mask
         path, ext = QtWidgets.QFileDialog.getSaveFileName(
-            self, "Save mask to", filter="*.npy"
+            self, "Save mask to", "mask.png" ,filter="*.png;;*.npy"
         )
         if path:
-            np.save(path, self.mask)
+            if path.endswith(".png"):
+                plt.imsave(path, self.mask, cmap='gray')
+            elif path.endswith(".npy"):
+                np.save(path, self.mask)
 
     def load_mask(self):
         """ Loads binary mask from .npy format. """

--- a/picasso/gui/render.py
+++ b/picasso/gui/render.py
@@ -3753,7 +3753,7 @@ class MaskSettingsDialog(QtWidgets.QDialog):
         Parameters
         ----------
         locs : np.recarray
-            Localizations to lure masked
+            Localizations to be masked
         """
 
         x_ind = (

--- a/picasso/gui/render.py
+++ b/picasso/gui/render.py
@@ -3643,17 +3643,16 @@ class MaskSettingsDialog(QtWidgets.QDialog):
         self.H_blur = H_blur # image to be displayed in self.ax2
 
     def save_mask(self):
-        """ Saves binary mask from .npy to a .png format """
+        """ Saves binary mask to a .png and .npy format """
 
         # get name for saving mask
         path, ext = QtWidgets.QFileDialog.getSaveFileName(
             self, "Save mask to", "mask.png" ,filter="*.png;;*.npy"
         )
         if path:
-            if path.endswith(".png"):
-                plt.imsave(path, self.mask, cmap='gray')
-            elif path.endswith(".npy"):
-                np.save(path, self.mask)
+            plt.imsave(path, self.mask, cmap='gray')
+            npy_path = os.path.splitext(path)[0] + ".npy"
+            np.save(npy_path, self.mask)
 
     def load_mask(self):
         """ Loads binary mask from .npy format. """

--- a/picasso/gui/render.py
+++ b/picasso/gui/render.py
@@ -3647,7 +3647,7 @@ class MaskSettingsDialog(QtWidgets.QDialog):
 
         # get name for saving mask
         path, ext = QtWidgets.QFileDialog.getSaveFileName(
-            self, "Save mask to", "mask.png" ,filter="*.png;;*.npy"
+            self, "Save mask to","mask.png", filter="*.png;;*.npy"
         )
         if path:
             plt.imsave(path, self.mask, cmap='gray')

--- a/picasso/gui/render.py
+++ b/picasso/gui/render.py
@@ -3643,16 +3643,18 @@ class MaskSettingsDialog(QtWidgets.QDialog):
         self.H_blur = H_blur # image to be displayed in self.ax2
 
     def save_mask(self):
-        """ Saves binary mask to a .png and .npy format """
+        """ Saves binary mask to a .npy and .png format."""
 
-        # get name for saving mask
+        directory, file_name = os.path.split(self.paths[0])
+        base, ext = os.path.splitext(file_name)
+        name_mask = base + "_mask"
         path, ext = QtWidgets.QFileDialog.getSaveFileName(
-            self, "Save mask to","mask.png", filter="*.png;;*.npy"
+            self, "Save mask to", name_mask, filter="*.npy"
         )
         if path:
-            plt.imsave(path, self.mask, cmap='gray')
-            npy_path = os.path.splitext(path)[0] + ".npy"
-            np.save(npy_path, self.mask)
+            np.save(path, self.mask)
+            png_path = base + "_mask" + ".png"
+            plt.imsave(png_path, self.mask, cmap='gray')
 
     def load_mask(self):
         """ Loads binary mask from .npy format. """
@@ -3751,7 +3753,7 @@ class MaskSettingsDialog(QtWidgets.QDialog):
         Parameters
         ----------
         locs : np.recarray
-            Localizations to be masked
+            Localizations to lure masked
         """
 
         x_ind = (


### PR DESCRIPTION
#445 
This code change is a slight adaptation of #445. 
- Previously, the dialog field would give the user the option to select between .npy and png.
- Now, there is no further input needed from the user.
- The  default naming convention is: `file name` +`_mask` and with extension `.npy` or `.png`