### PR TITLE
Remove duplicate subparsers.

### DIFF
--- a/picasso/__main__.py
+++ b/picasso/__main__.py
@@ -1120,7 +1120,7 @@ def main():
     parser = argparse.ArgumentParser("picasso")
     subparsers = parser.add_subparsers(dest="command")
 
-    for command in ["toraw", "localize", "filter", "render"]:
+    for command in ["toraw",  "filter"]:
         subparsers.add_parser(command)
 
     # link parser


### PR DESCRIPTION
Some subparsers were added twice. This is allowed in python 3.10 but triggers an error in python 3.11 Removing one of the times the subparsers were added is cleaner, harmless in Python 3.10, and enables to use picasso with newer Python versions.