### PR TITLE
v0.7.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.0
+current_version = 0.7.1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-Last change: 18-SEP-2024 MTS
+Last change: 19-SEP-2024 MTS
 
 0.7.1
 -----

--- a/changelog.rst
+++ b/changelog.rst
@@ -5,16 +5,19 @@ Last change: 19-SEP-2024 MTS
 
 0.7.1
 -----
+- SMLM clusterer in picked regions deleted
+- Show legend in Render property displayed rounded tick label values
+- Pick circular area does not save the area for each pick in localization's metadata 
+- Other minor bug fixes
+
+0.7.0
+-----
 - Adaptive Intersection Maximization (AIM, doi: 10.1038/s41592-022-01307-0) implemented
 - Z fitting improved by setting bounds on fitted z values to avoid NaNs
 - CMD ``clusterfile`` fixed 
 - Picasso: Render 3D, rectangular and polygonal pick fixed
 - ``picasso.localize.localize`` fixed
 - default MLE fitting uses different sx and sy (CMD only)
-- SMLM clusterer in picked regions deleted
-- Show legend in Render property displayed rounded tick label values
-- Pick circular area does not save the area for each pick in localization's metadata 
-- Other minor bug fixes
 
 0.6.9 - 0.6.11
 --------------

--- a/distribution/picasso.iss
+++ b/distribution/picasso.iss
@@ -2,10 +2,10 @@
 AppName=Picasso
 AppPublisher=Jungmann Lab, Max Planck Institute of Biochemistry
 
-AppVersion=0.7.0
+AppVersion=0.7.1
 DefaultDirName={commonpf}\Picasso
 DefaultGroupName=Picasso
-OutputBaseFilename="Picasso-Windows-64bit-0.7.0"
+OutputBaseFilename="Picasso-Windows-64bit-0.7.1"
 ArchitecturesAllowed=x64
 ArchitecturesInstallIn64BitMode=x64
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = "Maximilian T. Strauss"
 # The short X.Y version
 version = ""
 # The full version, including alpha/beta/rc tags
-release = "0.7.0"
+release = "0.7.1"
 
 # -- General configuration ---------------------------------------------------
 

--- a/picasso/__init__.py
+++ b/picasso/__init__.py
@@ -8,7 +8,7 @@
 import os.path as _ospath
 import yaml as _yaml
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 _this_file = _ospath.abspath(__file__)
 _this_dir = _ospath.dirname(_this_file)

--- a/picasso/__main__.py
+++ b/picasso/__main__.py
@@ -893,7 +893,7 @@ def _localize(args):
 
             try:
                 with open(zpath, "r") as f:
-                    z_calibration = yaml.load(f)
+                    z_calibration = yaml.full_load(f)
             except Exception as e:
                 print(e)
                 print("Error loading calibration file.")

--- a/picasso/__version__.py
+++ b/picasso/__version__.py
@@ -1,1 +1,1 @@
-VERSION_NO = "0.7.0"
+VERSION_NO = "0.7.1"

--- a/picasso/aim.py
+++ b/picasso/aim.py
@@ -612,7 +612,7 @@ def aim(
     roi_r=60/130,
     progress=None,
 ):
-    """Apply AIM algorithm to the localizations.
+    """Apply AIM undrifting to the localizations.
 
     Parameters
     ----------

--- a/release/one_click_windows_gui/create_installer_windows.bat
+++ b/release/one_click_windows_gui/create_installer_windows.bat
@@ -11,7 +11,7 @@ call conda activate picasso_installer
 call python setup.py sdist bdist_wheel
 
 call cd release/one_click_windows_gui
-call pip install "../../dist/picassosr-0.7.0-py3-none-any.whl"
+call pip install "../../dist/picassosr-0.7.1-py3-none-any.whl"
 
 call pip install pyinstaller==5.7
 call pyinstaller ../pyinstaller/picasso.spec -y --clean

--- a/release/one_click_windows_gui/picasso_innoinstaller.iss
+++ b/release/one_click_windows_gui/picasso_innoinstaller.iss
@@ -1,10 +1,10 @@
 [Setup]
 AppName=Picasso
 AppPublisher=Jungmann Lab, Max Planck Institute of Biochemistry
-AppVersion=0.7.0
+AppVersion=0.7.1
 DefaultDirName={commonpf}\Picasso
 DefaultGroupName=Picasso
-OutputBaseFilename="Picasso-Windows-64bit-0.7.0"
+OutputBaseFilename="Picasso-Windows-64bit-0.7.1"
 ArchitecturesAllowed=x64
 ArchitecturesInstallIn64BitMode=x64
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("readme.rst", encoding="utf-8") as readme_file:
 
 setup(
     name="picassosr",
-    version="0.7.0",
+    version="0.7.1",
     author="Joerg Schnitzbauer, Maximilian T. Strauss, Rafal Kowalewski",
     author_email=("joschnitzbauer@gmail.com, straussmaximilian@gmail.com, rafalkowalewski998@gmail.com"),
     url="https://github.com/jungmannlab/picasso",
@@ -18,7 +18,7 @@ setup(
     entry_points={
         "console_scripts": ["picasso=picasso.__main__:main"],
     },
-    install_requires=requirements + ["PyImarisWriter==0.7.0; sys_platform=='win32'"],
+    install_requires=requirements + ["PyImarisWriter==0.7.1; sys_platform=='win32'"],
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
- SMLM clusterer in picked regions deleted
- Show legend in Render property displayed rounded tick label values
- Pick circular area does not save the area for each pick in localization's metadata 
- Other minor bug fixes