### PR TITLE
v0.7.5

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.4
+current_version = 0.7.5
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,7 @@ Last change: 06-FEB-2025 MTS
 0.7.5
 -----
 - Automatic picking of fiducials added in Render: ``Tools/Pick fiducials``
+- Undrifting from picked moved from ``picasso/gui/render`` to ``picasso/postprocess``
 - Plugin docs update
 - Filter histogram display fixed for datasets with low variance (bug fix)
 - AIM undrifting works now if the first frames of localizations are filtered out (bug fix)

--- a/changelog.rst
+++ b/changelog.rst
@@ -9,6 +9,7 @@ Last change: 06-FEB-2025 MTS
 - Filter histogram display fixed for datasets with low variance (bug fix)
 - AIM undrifting works now if the first frames of localizations are filtered out (bug fix)
 - 2D drift plot in Render inverts y axis to match the rendered localizations
+- 3D animation fixed
 - Other minor bug fixes
 
 0.7.1 - 0.7.4

--- a/changelog.rst
+++ b/changelog.rst
@@ -6,7 +6,9 @@ Last change: 20-JAN-2025 MTS
 0.7.5
 -----
 - Plugin docs update
-- Bug fixes
+- Filter histogram display fixed for datasets with low variance (bug fix)
+- AIM undrifting works now if the first frames of localizations are filtered out (bug fix)
+- Other minor bug fixes
 
 0.7.1 - 0.7.4
 -------------

--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,7 @@ Last change: 20-JAN-2025 MTS
 0.7.5
 -----
 - Plugin docs update
+- Bug fixes
 
 0.7.1 - 0.7.4
 -------------

--- a/changelog.rst
+++ b/changelog.rst
@@ -5,6 +5,7 @@ Last change: 06-FEB-2025 MTS
 
 0.7.5
 -----
+- Automatic picking of fiducials added in Render: ``Tools/Pick fiducials``
 - Plugin docs update
 - Filter histogram display fixed for datasets with low variance (bug fix)
 - AIM undrifting works now if the first frames of localizations are filtered out (bug fix)

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,13 +1,14 @@
 Changelog
 =========
 
-Last change: 20-JAN-2025 MTS
+Last change: 06-FEB-2025 MTS
 
 0.7.5
 -----
 - Plugin docs update
 - Filter histogram display fixed for datasets with low variance (bug fix)
 - AIM undrifting works now if the first frames of localizations are filtered out (bug fix)
+- 2D drift plot in Render inverts y axis to match the rendered localizations
 - Other minor bug fixes
 
 0.7.1 - 0.7.4

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,7 +1,11 @@
 Changelog
 =========
 
-Last change: 14-DEC-2024 MTS
+Last change: 20-JAN-2025 MTS
+
+0.7.5
+-----
+- Plugin docs update
 
 0.7.1 - 0.7.4
 -------------

--- a/distribution/picasso.iss
+++ b/distribution/picasso.iss
@@ -2,10 +2,10 @@
 AppName=Picasso
 AppPublisher=Jungmann Lab, Max Planck Institute of Biochemistry
 
-AppVersion=0.7.4
+AppVersion=0.7.5
 DefaultDirName={commonpf}\Picasso
 DefaultGroupName=Picasso
-OutputBaseFilename="Picasso-Windows-64bit-0.7.4"
+OutputBaseFilename="Picasso-Windows-64bit-0.7.5"
 ArchitecturesAllowed=x64
 ArchitecturesInstallIn64BitMode=x64
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = "Maximilian T. Strauss"
 # The short X.Y version
 version = ""
 # The full version, including alpha/beta/rc tags
-release = "0.7.4"
+release = "0.7.5"
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -4,34 +4,33 @@ Plugins
 
 Usage
 -----
-Starting in version 0.5.0, Picasso allows for creating plugins. They can be added by the user for each of the available distributions of picasso (GitHub, picassosr from PyPI and the one click installer). However, using plugins in the latter may cause issues, see below.
+Starting in version 0.5.0, Picasso supports plugins. Please find the instructions on how to add them to your Picasso below. 
 
-Please keep in mind that the ``__init__.py`` file in the ``plugins`` folder must not be modified or deleted.
+Please keep in mind that the ``__init__.py`` file in the ``picasso/picasso/gui/plugins`` folder must not be modified or deleted.
 
 GitHub
 ~~~~~~
+If you cloned the GitHub repository, you can add plugins by following these steps:
 - Find the directory where you cloned the GitHub repository with Picasso.
 - Go to ``picasso/picasso/gui/plugins``.
 - Copy the plugin(s) to this folder.
-- The plugin(s) should automatically work after running picasso in the new command window.
 
 PyPI
 ~~~~
-- Find the location of the environment where picassosr is installed (type ``conda env list`` to see the directory).
-- Find this directory and go to ``YOUR_ENVIRONMENT/Lib/site-packages/picasso/gui/plugins``.
+If you installed Picasso using ``pip install picassosr``, you can add plugins by following these steps:
+- To find the location of the environment where ``picassosr`` is installed, type ``conda env list``.
+- If your environment can be found under ``YOUR_ENVIRONMENT``, go to ``YOUR_ENVIRONMENT/Lib/site-packages/picasso/gui/plugins``.
 - Copy the plugin(s) to this folder.
-- The plugin(s) should automatically work after running picasso in the new command window.
 
 One click installer
 ~~~~~~~~~~~~~~~~~~~
-**NOTE**: This may lead to issues if Picasso is installed, as the plugin scripts will remain in the ``plugins`` folder upon deinstallation. After deinstalltion, the ``Picasso`` folder needs to be deleted manually.
+**NOTE**: After deinstalling Picasso, ``Program Files/Picasso`` folder needs to be deleted manually, as the uninstaller currently does not remove the plugins automatically.
 
 - Find the location where you installed Picasso. By default, it is ``C:/Program Files/Picasso``.
 - Go to the following subfolder in the `Picasso` directory: ``picasso/gui/plugins``.
 - Copy the plugin(s) to this folder.
-- The plugin(s) should automatically be loaded after double-clicking the respective desktop shortcuts.
 
-**NOTE**: Plugins added in this distribution will not be able to use packages that are not installed automatically (from the file ``requirements.txt``).
+.. **NOTE**: Plugins added in this distribution will not be able to use packages that are not installed automatically (from the file ``requirements.txt``).
 
 For developers
 --------------
@@ -41,4 +40,4 @@ To create a plugin, you can use the template provided in ``picasso/plugin_templa
    :scale: 70 %
    :alt: Plugins
 
-As an example, please see any of the plugins on the GitHub `repo <https://github.com/rafalkowalewski1/picasso_plugins>`_.
+As an example, please see any of the plugins in the `GitHub repo <https://github.com/rafalkowalewski1/picasso_plugins>`_.

--- a/docs/render.rst
+++ b/docs/render.rst
@@ -61,6 +61,8 @@ The 3D rotation window allows the user to render 3D localization data. To use it
 
 The user may perform multiple actions in the rotation window, including: saving rotated localizations, building animations (.mp4 format), rotating by a specified angle, etc.
 
+Note that to build animations, the user must have ``ffmpeg`` installed on their system. 
+
 Rotation around z-axis is available by pressing Ctrl/Command. Rotation axis can be frozen by pressing x/y/z to freeze around the corresponding axes (to freeze around the z-axis, Ctrl/Command must be pressed as well).
 
 There are several things to keep in mind when using the rotation window. Firstly, using individual localization precision is very slow and is not recommended as a default blur method. Also, the size of the rotation window can be altered, however, if it becomes too large, rendering may start to lag.

--- a/picasso/__init__.py
+++ b/picasso/__init__.py
@@ -8,7 +8,7 @@
 import os.path as _ospath
 import yaml as _yaml
 
-__version__ = "0.7.4"
+__version__ = "0.7.5"
 
 _this_file = _ospath.abspath(__file__)
 _this_dir = _ospath.dirname(_this_file)

--- a/picasso/__version__.py
+++ b/picasso/__version__.py
@@ -1,1 +1,1 @@
-VERSION_NO = "0.7.4"
+VERSION_NO = "0.7.5"

--- a/picasso/aim.py
+++ b/picasso/aim.py
@@ -652,7 +652,7 @@ def aim(
         if val := inf.get("Height"):
             height = val
         if val := inf.get('Frames'):
-            n_frames = val
+            n_frames = val - locs["frame"].min()
         if val := inf.get("Pixelsize"):
             pixelsize = val
     if _np.isnan(width * height * pixelsize * n_frames):
@@ -662,7 +662,8 @@ def aim(
         )
 
     # frames should start at 1 
-    frame = locs["frame"] + 1
+    frame = locs["frame"] + 1 - locs["frame"].min()
+
     # find the segmentation bounds (temporal intervals)
     seg_bounds = _np.concatenate((
         _np.arange(0, n_frames, segmentation), [n_frames]

--- a/picasso/aim.py
+++ b/picasso/aim.py
@@ -628,7 +628,8 @@ def aim(
         Radius of the local search region in camera pixels. Should be 
         larger than the  maximum expected drift within segmentation.
     progress : picasso.lib.ProgressDialog (default=None)
-        Progress dialog. If None, progress is displayed with tqdm.
+        Progress dialog. If None, progress is displayed with into the 
+        console.
     
     Returns
     -------
@@ -655,7 +656,10 @@ def aim(
         if val := inf.get("Pixelsize"):
             pixelsize = val
     if _np.isnan(width * height * pixelsize * n_frames):
-        raise KeyError("Insufficient metadata available.")
+        raise KeyError(
+            "Insufficient metadata available. Please specify 'Width', 'Height',"
+            " 'Frames' and 'Pixelsize' in the metadata .yaml."
+        )
 
     # frames should start at 1 
     frame = locs["frame"] + 1

--- a/picasso/gui/render.py
+++ b/picasso/gui/render.py
@@ -5785,7 +5785,7 @@ class View(QtWidgets.QLabel):
         if update_scene:
             self.update_scene()
 
-    def add_polygon_point(self, point_movie, point_screen, update_scene=True):
+    def add_polygon_point(self, point_movie, point_screen):
         """Adds a new point to the polygon or closes the current 
         polygon."""
 
@@ -5796,6 +5796,9 @@ class View(QtWidgets.QLabel):
             # to be added
             if len(self._picks[-1]) < 3: # cannot close polygon yet
                 self._picks[-1].append(point_movie)
+            # if the last polygon has been closed, start a new pick
+            elif self._picks[-1][0] == self._picks[-1][-1]:
+                self._picks.append([point_movie])
             else:
                 # check the distance between the current point and the 
                 # starting point of the currently drawn polygon
@@ -5807,8 +5810,7 @@ class View(QtWidgets.QLabel):
                 # close the polygon
                 if distance2 < POLYGON_POINTER_SIZE ** 2: 
                     self._picks[-1].append(self._picks[-1][0])
-                    self._picks.append([])
-                else: # add a new point
+                else: # add a new point to the existing pick
                     self._picks[-1].append(point_movie)
         self.update_pick_info_short()
         self.update_scene(picks_only=True)
@@ -9205,6 +9207,12 @@ class View(QtWidgets.QLabel):
             elif self._pick_shape == "Rectangle":
                 w = self.window.tools_settings_dialog.pick_width.value()
                 pick_info["Pick Width"] = w
+            # if polygon pick and the last not closed, ignore the last pick
+            elif (
+                self._pick_shape == "Polygon" 
+                and self._picks[-1][0] != self._picks[-1][-1]
+            ):
+                pick_info["Number of picks"] -= 1
             io.save_locs(path, locs, self.infos[channel] + [pick_info])
 
     def save_picked_locs_multi(self, path):

--- a/picasso/gui/render.py
+++ b/picasso/gui/render.py
@@ -5428,6 +5428,8 @@ class View(QtWidgets.QLabel):
         Moves viewport by a given relative distance
     pick_areas()
         Finds the areas of all current picks in um^2.
+    pick_fiducials()
+        Finds the circular picks centered around the fiducials
     pick_message_box(params)
         Returns a message box for selecting picks
     pick_similar()
@@ -8597,6 +8599,34 @@ class View(QtWidgets.QLabel):
         areas *= (pixelsize * 1e-3) ** 2 # convert to um^2
         return areas
 
+    def pick_fiducials(self):
+        """Finds the circular picks centered around the fiducials."""
+
+        channel = self.get_channel("Pick fiducials")
+        if channel is None:
+            return
+        
+        if self._pick_shape != "Circle":
+            message = "Please select circular pick before picking fiducials."
+            QtWidgets.QMessageBox.warning(self, "Warning", message)
+            return
+        if len(self._picks):
+            message = "Please remove all picks before picking fiducials."
+            QtWidgets.QMessageBox.warning(self, "Warning", message)
+            return
+        
+        locs = self.all_locs[channel]
+        info = self.infos[channel]
+        picks, box = imageprocess.find_fiducials(locs, info)
+
+        if len(picks) == 0:
+            message = "No fiducials found, manual picking is required."
+            QtWidgets.QMessageBox.warning(self, "Warning", message)
+            return
+        
+        self.window.tools_settings_dialog.pick_diameter.setValue(box)
+        self.add_picks(picks)
+
     @check_picks
     def pick_similar(self):
         """
@@ -10950,6 +10980,9 @@ class Window(QtWidgets.QMainWindow):
 
         move_to_pick_action = tools_menu.addAction("Move to pick")
         move_to_pick_action.triggered.connect(self.view.move_to_pick)
+
+        pick_fiducials_action = tools_menu.addAction("Pick fiducials")
+        pick_fiducials_action.triggered.connect(self.view.pick_fiducials)
 
         tools_menu.addSeparator()
         show_trace_action = tools_menu.addAction("Show trace")

--- a/picasso/gui/render.py
+++ b/picasso/gui/render.py
@@ -2897,6 +2897,7 @@ class DriftPlotWindow(QtWidgets.QTabWidget):
 
         ax2.set_xlabel("x (nm)")
         ax2.set_ylabel("y (nm)")
+        ax2.inverse_yaxis()
         ax3 = self.figure.add_subplot(133)
         ax3.plot(drift.z, label="z")
         ax3.legend(loc="best")
@@ -2937,6 +2938,7 @@ class DriftPlotWindow(QtWidgets.QTabWidget):
 
         ax2.set_xlabel("x (nm)")
         ax2.set_ylabel("y (nm)")
+        ax2.invert_yaxis()
 
         self.canvas.draw()
 

--- a/picasso/gui/rotation.py
+++ b/picasso/gui/rotation.py
@@ -16,8 +16,7 @@ from functools import partial
 
 import numpy as np
 import matplotlib.pyplot as plt
-# from moviepy.video.io.ImageSequenceClip import ImageSequenceClip
-import imageio
+import imageio.v2 as imageio
 from PyQt5 import QtCore, QtGui, QtWidgets
 
 from numpy.lib.recfunctions import stack_arrays
@@ -612,6 +611,7 @@ class AnimationDialog(QtWidgets.QDialog):
                 height += 1
 
             # render all frames and save in RAM
+            # video_writer = imageio.get_writer(name, fps=self.fps.value(),codec='libx264', format='FFMPEG')
             video_writer = imageio.get_writer(name, fps=self.fps.value())
             progress = lib.ProgressDialog(
                 "Rendering frames", 0, len(angx), self.window

--- a/picasso/lib.py
+++ b/picasso/lib.py
@@ -629,14 +629,14 @@ def pick_areas_polygon(picks):
         Pick areas.
     """
 
-    areas = _np.zeros(len(picks))
+    areas = []
     for i, pick in enumerate(picks):
         if len(pick) < 3 or pick[0] != pick[-1]: # not a closed polygon
-            areas[i] = 0
             continue
         X, Y = get_pick_polygon_corners(pick)
-        areas[i] = polygon_area(X, Y)
-    areas = areas[areas > 0] # remove open polygons
+        areas.append(polygon_area(X, Y))
+    areas = _np.array(areas)
+    areas = areas[areas > 0] # remove open polygons #TODO: delete this line?
     return areas
 
 

--- a/picasso/lib.py
+++ b/picasso/lib.py
@@ -133,11 +133,11 @@ def calculate_optimal_bins(data, max_n_bins=None):
     if data.dtype.kind in ("u", "i") and bin_size < 1:
         bin_size = 1
     bin_min = data.min() - bin_size / 2
-    n_bins = _np.ceil((data.max() - bin_min) / bin_size)
     try:
+        n_bins = (data.max() - bin_min) / bin_size
         n_bins = int(n_bins)
-    except ValueError:
-        return None
+    except:
+        n_bins = 10
     if max_n_bins and n_bins > max_n_bins:
         n_bins = max_n_bins
     bins = _np.linspace(bin_min, data.max(), n_bins)

--- a/readme.rst
+++ b/readme.rst
@@ -135,10 +135,12 @@ If you use picasso in your research, please cite our Nature Protocols publicatio
 |
 | If you use some of the functionalities provided by Picasso, please also cite the respective publications:
 
-- Nearest Neighbor based Analysis (NeNA) for experimental localization precision. DOI: `https://doi.org/10.1007/s00418-014-1192-3 <https://doi.org/10.1007/s00418-014-1192-3>`__
-- Theoretical localization precision (Gauss LQ and MLE). DOI: `https://doi.org/10.1038/nmeth.1447 <https://doi.org/10.1038/nmeth.1447>`__
-- MLE fitting. DOI: `https://doi.org/10.1038/nmeth.1449 <https://doi.org/10.1038/nmeth.1449>`__
+- Nearest Neighbor based Analysis (NeNA) for experimental localization precision. DOI: `10.1007/s00418-014-1192-3 <https://doi.org/10.1007/s00418-014-1192-3>`__
+- Theoretical localization precision (Gauss LQ and MLE). DOI: `10.1038/nmeth.1447 <https://doi.org/10.1038/nmeth.1447>`__
+- MLE fitting. DOI: `10.1038/nmeth.1449 <https://doi.org/10.1038/nmeth.1449>`__
 - AIM undrifting. DOI: `10.1126/sciadv.adm776 <https://www.science.org/doi/10.1126/sciadv.adm7765>`__
+- DBSCAN: Ester, et al. Inkdd, 1996. (Vol. 96, No. 34, pp. 226-231).
+- HDBSCAN. DOI: `10.1007/978-3-642-37456-2_14 <https://doi.org/10.1007/978-3-642-37456-2_14>`__
 
 Credits
 -------

--- a/release/one_click_windows_gui/create_installer_windows.bat
+++ b/release/one_click_windows_gui/create_installer_windows.bat
@@ -11,7 +11,7 @@ call conda activate picasso_installer
 call python setup.py sdist bdist_wheel
 
 call cd release/one_click_windows_gui
-call pip install "../../dist/picassosr-0.7.4-py3-none-any.whl"
+call pip install "../../dist/picassosr-0.7.5-py3-none-any.whl"
 
 call pip install pyinstaller==5.12
 call pyinstaller ../pyinstaller/picasso.spec -y --clean

--- a/release/one_click_windows_gui/create_installer_windows.bat
+++ b/release/one_click_windows_gui/create_installer_windows.bat
@@ -5,7 +5,7 @@ call RMDIR /Q/S dist
 
 call cd %~dp0\..\..
 
-call conda create -n picasso_installer python=3.10 -y
+call conda create -n picasso_installer python=3.10.15 -y
 call conda activate picasso_installer
 
 call python setup.py sdist bdist_wheel

--- a/release/one_click_windows_gui/picasso_innoinstaller.iss
+++ b/release/one_click_windows_gui/picasso_innoinstaller.iss
@@ -1,10 +1,10 @@
 [Setup]
 AppName=Picasso
 AppPublisher=Jungmann Lab, Max Planck Institute of Biochemistry
-AppVersion=0.7.4
+AppVersion=0.7.5
 DefaultDirName={commonpf}\Picasso
 DefaultGroupName=Picasso
-OutputBaseFilename="Picasso-Windows-64bit-0.7.4"
+OutputBaseFilename="Picasso-Windows-64bit-0.7.5"
 ArchitecturesAllowed=x64
 ArchitecturesInstallIn64BitMode=x64
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ scikit-learn==1.3.1
 tqdm==4.66.1
 lmfit==1.2.2
 streamlit==1.27.0
-moviepy==1.0.3
 nd2==0.7.2
 sqlalchemy==2.0.21
 plotly-express==0.4.1

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("readme.rst", encoding="utf-8") as readme_file:
 
 setup(
     name="picassosr",
-    version="0.7.4",
+    version="0.7.5",
     author="Joerg Schnitzbauer, Maximilian T. Strauss, Rafal Kowalewski",
     author_email=("joschnitzbauer@gmail.com, straussmaximilian@gmail.com, rafalkowalewski998@gmail.com"),
     url="https://github.com/jungmannlab/picasso",


### PR DESCRIPTION
- Automatic picking of fiducials added in Render: ``Tools/Pick fiducials``
- Undrifting from picked moved from ``picasso/gui/render`` to ``picasso/postprocess``
- Plugin docs update
- Filter histogram display fixed for datasets with low variance (bug fix)
- AIM undrifting works now if the first frames of localizations are filtered out (bug fix)
- 2D drift plot in Render inverts y axis to match the rendered localizations
- 3D animation fixed
- Other minor bug fixes