### PR TITLE
fix: allow for localization loading of h5py.Group objects

### DIFF
--- a/picasso/io.py
+++ b/picasso/io.py
@@ -4209,26 +4209,30 @@ def _read_locs_dataset(path: str, progress=None) -> pd.DataFrame:
         if "locs" not in locs_file:
             raise KeyError(f"File: {path} does not contain a 'locs' dataset.")
         dataset = locs_file["locs"]
-        names = getattr(dataset.dtype, "names", None)
-        if not isinstance(dataset, h5py.Dataset) or names is None:
-            dataset = None  # not a Picasso-written compound dataset
-        if dataset is not None:
-            n_locs = len(dataset)
-            # fill one contiguous array per column, such that no copy of
-            # the whole dataset is needed to build the DataFrame
-            columns = {
-                name: np.empty(n_locs, dtype=dataset.dtype[name])
-                for name in names
-            }
-            for start in range(0, max(n_locs, 1), BLOCK_SIZE):
-                stop = min(start + BLOCK_SIZE, n_locs)
-                block = dataset[start:stop]
-                for name in names:
-                    columns[name][start:stop] = block[name]
-                if progress is not None:
-                    progress(stop, n_locs)
-            return pd.DataFrame(columns, copy=False)
-    return pd.read_hdf(path, key="locs")
+        
+        # Only Picasso compound datasets can be read block-wise with h5py.
+        if isinstance(dataset, h5py.Dataset):
+            names = getattr(dataset.dtype, "names", None)
+            
+            if names is not None:
+                n_locs = len(dataset)
+                # fill one contiguous array per column, such that no copy of
+                # the whole dataset is needed to build the DataFrame
+                columns = {
+                    name: np.empty(n_locs, dtype=dataset.dtype[name])
+                    for name in names
+                }
+                for start in range(0, max(n_locs, 1), BLOCK_SIZE):
+                    stop = min(start + BLOCK_SIZE, n_locs)
+                    block = dataset[start:stop]
+                    for name in names:
+                        columns[name][start:stop] = block[name]
+                    if progress is not None:
+                        progress(stop, n_locs)
+                return pd.DataFrame(columns, copy=False)
+             
+        # Non-compound HDF5 layouts are handled by PyTables/pandas.
+        return pd.read_hdf(path, key="locs")
 
 
 def load_locs(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -192,6 +192,28 @@ class TestSaveLoadLocs:
         np.testing.assert_allclose(
             loaded["x"].to_numpy(), locs["x"].to_numpy()
         )
+    
+    def test_load_locs_falls_back_for_hdf5_group(
+        self, tmp_path, locs, info
+    ):
+        # Regression test for HDF5 files where /locs is an h5py.Group
+        # rather than a Picasso compound Dataset. The h5py reader must
+        # not access .dtype on the Group and should fall back to pandas.
+        path = tmp_path / "locs.hdf5"
+
+        locs.to_hdf(path, key="locs", mode="w", format="fixed")
+
+        with h5py.File(path, "r") as f:
+            assert isinstance(f["locs"], h5py.Group)
+
+        loaded = io._read_locs_dataset(str(path))
+
+        assert len(loaded) == len(locs)
+        assert set(loaded.columns) == set(locs.columns)
+        np.testing.assert_allclose(
+            loaded["x"].to_numpy(),
+            locs["x"].to_numpy(),
+        )
 
     def test_combine_channels_inner_join_preserves_all_rows(
         self, tmp_path, locs, info


### PR DESCRIPTION
Hi @rafalkowalewski1,

Thanks for the massive update to v0.11.0. I was trying it out today, but I noticed that I could not open my localization files.


## Issue
When I try to open my localization files in the renderer, I get the following error:

<img width="292" height="101" alt="image" src="https://github.com/user-attachments/assets/d4f0f328-2d78-4855-857f-0a0235b47fc3" />

In the past, I wrote some code save to localizations to `.hdf5` files, based on the way Picasso did it for a while (but apparently doesn't do anymore) using `locs.to_hdf()`:

https://github.com/jungmannlab/picasso/blob/87c2a2a15d445b65cb32bea0604b34922a5952e6/picasso/io.py#L4169

## The culprit

I found out that apparently `to_hdf` seems to save the data as a `Group` object, which does not have a `.dtype` attribute, but is since `v0.11.0` expected to exist, as can be seen here:

https://github.com/jungmannlab/picasso/blob/87c2a2a15d445b65cb32bea0604b34922a5952e6/picasso/io.py#L4212

## What I did

* I have moved the `getattr` call into an if-block that checks whether the dataset is a `h5py.Dataset` if not, it uses `pd.read_hdf()`.
* I have also added a test that fails on `master` and passes in this branch.

Let me know if you have any questions. Or feel free to fix it in a different manner of course, but it would be great if `h5py.Group` objects could still be loaded into Picasso.

Best,
Boyd




